### PR TITLE
Update vendor of php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "fabpot/php-cs-fixer": "~1.0",
+        "friendsofphp/php-cs-fixer": "^1.11",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit-mock-objects": "~3.0",
         "phpunit/phpunit": "~5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5144d9bdc340fa23d1e24e38bf39e4ce",
-    "content-hash": "5580ad0cec9fd04c04c13c6f12a01d85",
+    "hash": "d76048991b0b7fc2029345424153aebd",
+    "content-hash": "52b9c4162146276fd9114e40d2195921",
     "packages": [
         {
             "name": "bruli/ignore-files",
@@ -104,60 +104,6 @@
             "time": "2015-06-14 21:17:01"
         },
         {
-            "name": "fabpot/php-cs-fixer",
-            "version": "v1.11.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "41f70154642ec0f9ea9ea9c290943f3b5dfa76fc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/41f70154642ec0f9ea9ea9c290943f3b5dfa76fc",
-                "reference": "41f70154642ec0f9ea9ea9c290943f3b5dfa76fc",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
-            },
-            "require-dev": {
-                "satooshi/php-coveralls": "0.7.*@dev"
-            },
-            "bin": [
-                "php-cs-fixer"
-            ],
-            "type": "application",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\CS\\": "Symfony/CS/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "A tool to automatically fix PHP code style",
-            "time": "2016-02-26 07:37:29"
-        },
-        {
             "name": "fiunchinho/phpunit-randomizer",
             "version": "2.0.2",
             "source": {
@@ -203,6 +149,60 @@
                 "unit testing"
             ],
             "time": "2014-12-19 17:21:11"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v1.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "b0a383d856d884d6b16e15892f507ecf89f8dbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b0a383d856d884d6b16e15892f507ecf89f8dbd2",
+                "reference": "b0a383d856d884d6b16e15892f507ecf89f8dbd2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/event-dispatcher": "~2.1|~3.0",
+                "symfony/filesystem": "~2.1|~3.0",
+                "symfony/finder": "~2.1|~3.0",
+                "symfony/process": "~2.3|~3.0",
+                "symfony/stopwatch": "~2.5|~3.0"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2016-05-26 23:49:24"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
+++ b/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
@@ -21,7 +21,7 @@ abstract class ToolHandler
     /** @var array */
     private $tools = array(
         'phpcs' => 'squizlabs/php_codesniffer',
-        'php-cs-fixer' => 'fabpot/php-cs-fixer',
+        'php-cs-fixer' => 'friendsofphp/php-cs-fixer',
         'phpmd' => 'phpmd/phpmd',
         'phpunit' => 'phpunit/phpunit',
         'phpunit-randomizer' => 'fiunchinho/phpunit-randomizer',


### PR DESCRIPTION
The vendor name of php-cs-fixer is deprecated.
Replace all `fabpot/php-cs-fixer` with `friendsofphp/php-cs-fixer`.